### PR TITLE
fix: detect new untracked files in aggregation workflow

### DIFF
--- a/.github/workflows/aggregate-llms-txt.yml
+++ b/.github/workflows/aggregate-llms-txt.yml
@@ -30,10 +30,12 @@ jobs:
         env:
           GH_TOKEN: ${{ github.token }}
         run: |
-          if git diff --quiet; then
+          git add docs/llms.txt docs/llms-full.txt 2>/dev/null || true
+          if git diff --cached --quiet; then
             echo "No changes to commit"
             exit 0
           fi
+          git reset HEAD -- . > /dev/null
 
           # Ensure standing issue #8 is open for linked-issue check
           ISSUE_STATE=$(gh issue view 8 --json state -q '.state')


### PR DESCRIPTION
Closes #10

## Summary
- Stage files before checking for changes so new untracked files (first-time `llms.txt` creation) are detected
- Previously `git diff --quiet` only checked tracked files and exited early with "No changes to commit"

## Test plan
- [ ] Trigger `workflow_dispatch` on `aggregate-llms-txt.yml`
- [ ] Workflow detects the new `docs/llms.txt` and `docs/llms-full.txt` files
- [ ] PR is created with the federated content

🤖 Generated with [Claude Code](https://claude.com/claude-code)