### PR TITLE
fix: remove non-existent label from aggregation workflow

### DIFF
--- a/.github/workflows/aggregate-llms-txt.yml
+++ b/.github/workflows/aggregate-llms-txt.yml
@@ -54,6 +54,5 @@ jobs:
           if [ -z "$EXISTING_PR" ]; then
             gh pr create \
               --title "chore: update federated llms.txt" \
-              --body "Automated update of federated llms.txt from child documentation sites. Closes #8" \
-              --label "automated"
+              --body "Automated update of federated llms.txt from child documentation sites. Closes #8"
           fi


### PR DESCRIPTION
Closes #13

## Summary
- Remove `--label "automated"` from `gh pr create` in the aggregation workflow
- The label doesn't exist on the repo, causing PR creation to fail

🤖 Generated with [Claude Code](https://claude.com/claude-code)