### PR TITLE
docs: simplify homepage text by removing F5 XC brand references

### DIFF
--- a/docs/index.mdx
+++ b/docs/index.mdx
@@ -23,7 +23,7 @@ Terminal users can start with the **xcsh CLI**, VS Code users get full resource 
 
 ## MCP Servers
 
-Integrate F5 XC with AI coding assistants like Claude, Copilot, and others through Model Context Protocol servers.
+Integrate with AI coding assistants like Claude, Copilot, and others through Model Context Protocol servers.
 
 <CardGrid>
   <LinkCard title="API MCP Server" description="1,500+ API tools with dynamic discovery and 95%+ token savings" href="https://robinmordasiewicz.github.io/f5xc-api-mcp/" />
@@ -32,7 +32,7 @@ Integrate F5 XC with AI coding assistants like Claude, Copilot, and others throu
 
 ## Libraries & APIs
 
-For developers building on the F5 XC platform — credential management and validated OpenAPI specifications.
+For developers building on the credential management and validated OpenAPI specifications.
 
 <CardGrid>
   <LinkCard title="Auth Library" description="XDG-compliant profile management and credential handling for TypeScript/Node.js" href="https://robinmordasiewicz.github.io/f5xc-auth/" />
@@ -49,7 +49,7 @@ Administration guides for network engineers configuring Cloud services.
 
 ## Platform
 
-The shared build system and theme powering all F5 XC documentation sites.
+The shared build system and theme powering all documentation sites.
 
 <CardGrid>
   <LinkCard title="Docs Builder" icon="setting" description="Containerized Astro + Starlight build system for branded documentation sites." href="https://robinmordasiewicz.github.io/f5xc-docs-builder" />


### PR DESCRIPTION
Closes #27