### PR TITLE
docs: simplify homepage hero tagline

### DIFF
--- a/docs/index.mdx
+++ b/docs/index.mdx
@@ -4,7 +4,7 @@ description: Central documentation hub
 template: splash
 hero:
   title: Cloud Documentation
-  tagline: This documentation hub aggregates all the tools, libraries, and administration guides.
+  tagline: tools, libraries, and administration guides.
 ---
 
 import { Card, CardGrid, LinkCard } from '@astrojs/starlight/components';


### PR DESCRIPTION
## Summary
- Simplify the homepage hero tagline by removing the redundant prefix for brevity

## Changes
- `docs/index.mdx`: Updated tagline from "This documentation hub aggregates all the tools, libraries, and administration guides." to "tools, libraries, and administration guides."

Closes #37

## Test plan
- [ ] Verify the homepage renders correctly with the updated tagline
- [ ] Confirm no other content is affected

🤖 Generated with [Claude Code](https://claude.com/claude-code)