### PR TITLE
feat: add concurrency settings to workflows

### DIFF
--- a/.github/workflows/sync-llms-links.yml
+++ b/.github/workflows/sync-llms-links.yml
@@ -12,6 +12,10 @@ permissions:
   pull-requests: write
   issues: write
 
+concurrency:
+  group: sync-llms-links
+  cancel-in-progress: true
+
 jobs:
   sync:
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Summary

Add `concurrency` blocks to repo-specific workflows to prevent duplicate runs and save runner minutes.

Closes #78

## Test plan

- [ ] CI checks pass
- [ ] Workflow runs show concurrency group in metadata

🤖 Generated with [Claude Code](https://claude.com/claude-code)